### PR TITLE
README.md: Change the link of ImageNet2012 data manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pip install Pillow sklearn requests Wand tqdm
 ### Data preparation
 
 We assume you already have the following data:
-* ImageNet2012 raw images and tfrecord. For this data, please refer to [here](https://github.com/tensorflow/models/tree/master/research/slim#an-automated-script-for-processing-imagenet-data)
+* ImageNet2012 raw images and tfrecord. For this data, please refer to [here](https://github.com/simnalamburt/models/tree/clovaai-assembled-cnn/research/slim#an-automated-script-for-processing-imagenet-data)
 * For knowledge distillation, you need to add the teacher's logits to the TFRecord according to [here](./kd/README.md)
 * For transfer learing datasets, refer to scripts in [here](./datasets)
 * To download pretrained model, visit [here](https://drive.google.com/drive/folders/1o8vj8_ZOPByjRKZzRPZMbuoKyxIwd_IZ?usp=sharing)


### PR DESCRIPTION
Currently, tensorflow/models repository's slim bazel BUILD file is broken and not working (tensorflow/models#9539). Using the old BUILD file is not working too due to change of the URL. So I forked the tensorflow/models project and updated the bazel BUILD file just for this project, and changing the Link might be helpful for the other developers.

###### References
- https://github.com/tensorflow/models/issues/9539
- https://github.com/simnalamburt/models/commit/b95a173087cbc30394dc54eec1a2cf0033c9f173